### PR TITLE
use github compatible header ids

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -21,6 +21,10 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+
+    showdown: {
+      ghCompatibleHeaderId: true,
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
This will fix the issue with RFCs like https://rfcs.emberjs.com/id/0800-ts-adoption-plan/ where the outline links to different parts of the page 

e.g. https://rfcs.emberjs.com/id/0800-ts-adoption-plan/#classic-features doesn't work but it should work in the netlify preview for this PR

edit: it does work 🎉  https://deploy-preview-6--ember-rfcs.netlify.app/id/0800-ts-adoption-plan/#classic-features